### PR TITLE
Configuration checker (expressions/formulas only)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,10 +8,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up Zulu's JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: '11'
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
@@ -1,11 +1,17 @@
 package com.kraby.mcarcinizer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import com.kraby.mcarcinizer.deathkeeper.DeathKeeperSubplugin;
 import com.kraby.mcarcinizer.healthhardcorizer.HealthHardcorizerSubplugin;
 import com.kraby.mcarcinizer.mcarcinizer.commands.InvSizeCommand;
+import com.kraby.mcarcinizer.mcarcinizer.InfoLogs;
+import com.kraby.mcarcinizer.mcarcinizer.commands.CheckConfigCommand;
 import com.kraby.mcarcinizer.mcarcinizer.commands.ReloadCommand;
+import com.kraby.mcarcinizer.utils.config.ConfigAccessor;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
 
 
@@ -49,6 +55,24 @@ public class CarcinizerMain extends JavaPlugin {
     private void registerCommands() {
         this.getCommand("carcreload").setExecutor(new ReloadCommand());
         this.getCommand("invsize").setExecutor(new InvSizeCommand());
+    }
+
+
+    /**
+     * Returns all errors found in subplugins configurations.
+     * @return a non null list.
+     */
+    public List<String> getConfigErrors() {
+        List<String> errors = new ArrayList<>();
+        for (Subplugin sp : this.getSubplugins()) {
+            String pluginPrefix = ChatColor.YELLOW + "(" + sp.getName() + ") ";
+            for (ConfigAccessor conf : sp.getConfigAccessors()) {
+                for (String error : conf.getErrors()) {
+                    errors.add(pluginPrefix + ChatColor.RED + error);
+                }
+            }
+        }
+        return errors;
     }
 
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
@@ -26,6 +26,7 @@ public class CarcinizerMain extends JavaPlugin {
         setSingleton(this);
         initializeSubPlugins();
         registerCommands();
+        checkForErrors();
     }
 
 
@@ -48,6 +49,7 @@ public class CarcinizerMain extends JavaPlugin {
     }
 
     private void initializeSubPlugins() {
+        subplugins.clear();
         subplugins.add(new DeathKeeperSubplugin(this));
         subplugins.add(new HealthHardcorizerSubplugin(this));
     }
@@ -55,6 +57,7 @@ public class CarcinizerMain extends JavaPlugin {
     private void registerCommands() {
         this.getCommand("carcreload").setExecutor(new ReloadCommand());
         this.getCommand("invsize").setExecutor(new InvSizeCommand());
+        this.getCommand("carcchkcfg").setExecutor(new CheckConfigCommand());
     }
 
 
@@ -73,6 +76,11 @@ public class CarcinizerMain extends JavaPlugin {
             }
         }
         return errors;
+    }
+
+    private void checkForErrors() {
+        List<String> configErrors = getConfigErrors();
+        InfoLogs.warnIfConfigsContainErrors(Bukkit.getConsoleSender(), configErrors.size());
     }
 
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
@@ -28,6 +28,10 @@ public class CarcinizerMain extends JavaPlugin {
         //
     }
 
+    public List<Subplugin> getSubplugins() {
+        return Collections.unmodifiableList(subplugins);
+    }
+
     /**
      * Calls the reload method on all subplugins.
      */

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/CarcinizerMain.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import com.kraby.mcarcinizer.deathkeeper.DeathKeeperSubplugin;
 import com.kraby.mcarcinizer.healthhardcorizer.HealthHardcorizerSubplugin;
+import com.kraby.mcarcinizer.mcarcinizer.commands.InvSizeCommand;
 import com.kraby.mcarcinizer.mcarcinizer.commands.ReloadCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -43,6 +44,7 @@ public class CarcinizerMain extends JavaPlugin {
 
     private void registerCommands() {
         this.getCommand("carcreload").setExecutor(new ReloadCommand());
+        this.getCommand("invsize").setExecutor(new InvSizeCommand());
     }
 
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/Subplugin.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/Subplugin.java
@@ -2,6 +2,7 @@ package com.kraby.mcarcinizer;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.kraby.mcarcinizer.utils.config.ConfigAccessor;
 import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
@@ -46,9 +47,17 @@ public abstract class Subplugin {
     }
 
     /**
+     * Get this subplugin's name (should be unique).
+     * @return
+     */
+    public abstract String getName();
+
+    /**
      * Reload this subplugin's config, listeners, etc.
      */
     public abstract void reload();
+
+    public abstract List<ConfigAccessor> getConfigAccessors();
 
     protected abstract void createListeners();
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/expressions/variables/PlayerVariables.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/expressions/variables/PlayerVariables.java
@@ -1,6 +1,8 @@
 package com.kraby.mcarcinizer.carcinizer.expressions.variables;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import com.kraby.mcarcinizer.utils.InventorySerializer;
 import org.bukkit.Statistic;
@@ -8,14 +10,18 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
 public class PlayerVariables extends HashMap<String, Double> {
+
+    public static final String VARIABLE_INVSIZE = "INVSIZE";
+    public static final String VARIABLE_XP = "XP";
+
     public PlayerVariables(Player player) {
         populate(player);
     }
 
     protected void populate(Player player) {
         this.putAll(getStatisticsVariables(player));
-        this.put("INVSIZE", getInvSizeValue(player.getInventory()));
-        this.put("XP", Double.valueOf(player.getTotalExperience()));
+        this.put(VARIABLE_INVSIZE, getInvSizeValue(player.getInventory()));
+        this.put(VARIABLE_XP, Double.valueOf(player.getTotalExperience()));
     }
 
     private static Map<String, Double> getStatisticsVariables(Player p) {
@@ -34,5 +40,19 @@ public class PlayerVariables extends HashMap<String, Double> {
 
     public static double getInvSizeValue(Inventory inv) {
         return InventorySerializer.itemStackArrayToBase64(inv.getContents()).length();
+    }
+
+    /**
+     * Returns all accepted player variables.
+     * @return
+     */
+    public static List<String> getVariableNames() {
+        List<String> list = new ArrayList<>();
+        for (Statistic s : Statistic.values()) {
+            list.add(s.name());
+        }
+        list.add(VARIABLE_INVSIZE);
+        list.add(VARIABLE_XP);
+        return list;
     }
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/expressions/variables/PlayerVariables.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/expressions/variables/PlayerVariables.java
@@ -32,7 +32,7 @@ public class PlayerVariables extends HashMap<String, Double> {
         return variables;
     }
 
-    private static double getInvSizeValue(Inventory inv) {
+    public static double getInvSizeValue(Inventory inv) {
         return InventorySerializer.itemStackArrayToBase64(inv.getContents()).length();
     }
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/DeathKeeperSubplugin.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/DeathKeeperSubplugin.java
@@ -1,8 +1,10 @@
 package com.kraby.mcarcinizer.deathkeeper;
 
+import java.util.List;
 import com.kraby.mcarcinizer.Subplugin;
 import com.kraby.mcarcinizer.deathkeeper.config.DkConfig;
 import com.kraby.mcarcinizer.deathkeeper.listeners.ClassicDkListener;
+import com.kraby.mcarcinizer.utils.config.ConfigAccessor;
 import org.bukkit.plugin.Plugin;
 
 public class DeathKeeperSubplugin extends Subplugin {
@@ -58,5 +60,15 @@ public class DeathKeeperSubplugin extends Subplugin {
 
     public DkConfig getDkConfig() {
         return dkConfig;
+    }
+
+    @Override
+    public List<ConfigAccessor> getConfigAccessors() {
+        return List.of(dkConfig);
+    }
+
+    @Override
+    public String getName() {
+        return "DeathKeeper";
     }
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/listeners/ClassicDkListener.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/listeners/ClassicDkListener.java
@@ -24,7 +24,6 @@ import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitScheduler;
 
 public class ClassicDkListener implements Listener {
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/HealthHardcorizerSubplugin.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/HealthHardcorizerSubplugin.java
@@ -1,11 +1,13 @@
 package com.kraby.mcarcinizer.healthhardcorizer;
 
+import java.util.List;
 import com.kraby.mcarcinizer.Subplugin;
 import com.kraby.mcarcinizer.healthhardcorizer.config.GeneralConfig;
 import com.kraby.mcarcinizer.healthhardcorizer.config.RegenConfig;
 import com.kraby.mcarcinizer.healthhardcorizer.config.RespawnConfig;
 import com.kraby.mcarcinizer.healthhardcorizer.listeners.RegenListener;
 import com.kraby.mcarcinizer.healthhardcorizer.listeners.RespawnListener;
+import com.kraby.mcarcinizer.utils.config.ConfigAccessor;
 import org.bukkit.plugin.Plugin;
 
 public class HealthHardcorizerSubplugin extends Subplugin  {
@@ -89,5 +91,15 @@ public class HealthHardcorizerSubplugin extends Subplugin  {
 
     public RespawnConfig getRespawnConfig() {
         return respawnConfig;
+    }
+
+    @Override
+    public List<ConfigAccessor> getConfigAccessors() {
+        return List.of(generalConfig, regenConfig, respawnConfig);
+    }
+
+    @Override
+    public String getName() {
+        return "HealthHardcorizer";
     }
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/InfoLogs.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/InfoLogs.java
@@ -1,0 +1,25 @@
+package com.kraby.mcarcinizer.mcarcinizer;
+
+import com.kraby.mcarcinizer.mcarcinizer.commands.CheckConfigCommand;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+public class InfoLogs {
+
+    /**
+     * Warns the commandsender about configuration file errors presence.
+     * @param s
+     * @param errorCount
+     */
+    public static void warnIfConfigsContainErrors(CommandSender s, int errorCount) {
+        if (errorCount <= 0) {
+            return;
+        }
+
+        String message = String.format(
+            "%sYour configuration files contain at least %d errors. "
+            + "Type /%s to view a detailed list, fix them and reload.",
+            ChatColor.RED, errorCount, CheckConfigCommand.COMMAND_STRING);
+        s.sendMessage(message);
+    }
+}

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/CheckConfigCommand.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/CheckConfigCommand.java
@@ -1,0 +1,27 @@
+package com.kraby.mcarcinizer.mcarcinizer.commands;
+
+import java.util.List;
+import com.kraby.mcarcinizer.CarcinizerMain;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class CheckConfigCommand implements CommandExecutor {
+    public static final String COMMAND_STRING = "carcchkcfg";
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        List<String> errors = CarcinizerMain.getSingleton().getConfigErrors();
+
+        for (String error : errors) {
+            sender.sendMessage(error);
+        }
+
+        if (errors.isEmpty()) {
+            sender.sendMessage(ChatColor.GREEN + "Your config files are error free !");
+        }
+
+        return true;
+    }
+}

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/InvSizeCommand.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/InvSizeCommand.java
@@ -1,0 +1,27 @@
+package com.kraby.mcarcinizer.mcarcinizer.commands;
+
+import com.kraby.mcarcinizer.CarcinizerMain;
+import com.kraby.mcarcinizer.carcinizer.expressions.variables.PlayerVariables;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.InventoryHolder;
+import net.md_5.bungee.api.ChatColor;
+
+public class InvSizeCommand implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        CarcinizerMain.getSingleton().reloadSubplugin();
+        if (sender instanceof InventoryHolder) {
+            InventoryHolder ih = (InventoryHolder)sender;
+            double invSize = PlayerVariables.getInvSizeValue(ih.getInventory());
+            sender.sendMessage(ChatColor.YELLOW + "Your inventory size is " + invSize);
+        } else {
+            sender.sendMessage(ChatColor.RED
+                + "This command can only be called by an inventory holder");
+        }
+        return true;
+    }
+
+}

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/ReloadCommand.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/mcarcinizer/commands/ReloadCommand.java
@@ -1,6 +1,9 @@
 package com.kraby.mcarcinizer.mcarcinizer.commands;
 
+
+import java.util.List;
 import com.kraby.mcarcinizer.CarcinizerMain;
+import com.kraby.mcarcinizer.mcarcinizer.InfoLogs;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -12,6 +15,10 @@ public class ReloadCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         CarcinizerMain.getSingleton().reloadSubplugin();
         sender.sendMessage(ChatColor.GREEN + "MCarcinizer configs reloaded");
+
+        List<String> cfgErrors = CarcinizerMain.getSingleton().getConfigErrors();
+        InfoLogs.warnIfConfigsContainErrors(sender, cfgErrors.size());
+
         return true;
     }
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/utils/config/ConfigAccessor.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/utils/config/ConfigAccessor.java
@@ -2,6 +2,8 @@ package com.kraby.mcarcinizer.utils.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -40,5 +42,13 @@ public abstract class ConfigAccessor {
         }
 
         return config;
+    }
+
+    /**
+     * Get errors detected in this config file.
+     * @return Textual descriptions of the errors.
+     */
+    public List<String> getErrors() {
+        return new ArrayList<>();
     }
 }

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/utils/config/ConfigEvaluatorsChecker.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/utils/config/ConfigEvaluatorsChecker.java
@@ -1,0 +1,127 @@
+package com.kraby.mcarcinizer.utils.config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.kraby.mcarcinizer.carcinizer.expressions.ExpressionEvaluator;
+import com.kraby.mcarcinizer.carcinizer.expressions.exp4j.Exp4jEvaluator;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class ConfigEvaluatorsChecker {
+
+    public class Checker {
+        private static final double DUMMY_VALUE = -1 / 3.0D;
+
+        private final String expressionString;
+        private final String tag;
+        private final ExpressionEvaluator expressionEvaluator;
+
+        Checker(String exprString, String tag) {
+            this.expressionEvaluator = new Exp4jEvaluator(exprString);
+            this.expressionString = exprString;
+            this.tag = tag;
+        }
+
+        public String getTag() {
+            return tag;
+        }
+
+        public String getExpressionString() {
+            return expressionString;
+        }
+
+        /**
+         * Add given variable as provided to the evaluator.
+         * @param name
+         * @return The same checker instance, updated.
+         */
+        public Checker addVariable(String name) {
+            expressionEvaluator.setVariable(name, DUMMY_VALUE);
+            return this;
+        }
+
+        /**
+         * Add given variables as provided to the evaluator.
+         * @param names
+         * @return The same checker instance, updated.
+         */
+        public Checker addVariables(List<String> names) {
+            Map<String, Double> map = new HashMap<>();
+            for (String name : names) {
+                map.put(name, DUMMY_VALUE);
+            }
+            expressionEvaluator.setVariables(map);
+            return this;
+        }
+
+        public boolean isValid() {
+            return expressionEvaluator.isValid();
+        }
+
+        public List<String> getErrors() {
+            return expressionEvaluator.getErrors();
+        }
+    }
+
+    private List<Checker> checkers = new ArrayList<>();
+
+    /**
+     * Registers an evaluator from an expression string.
+     * @param exprString
+     * @return The registered evaluator checker.
+     */
+    public Checker registerEvaluator(String exprString, String tag) {
+        Checker e = new Checker(exprString, tag);
+        checkers.add(e);
+        return e;
+    }
+
+    /**
+     * Registers an evaluator from a config file and a field path.
+     * @param config
+     * @param fieldName
+     * @return The registered evaluator checker.
+     */
+    public Checker registerEvaluator(FileConfiguration config, String fieldName) {
+        String expString = config.getString(fieldName, "!<" + fieldName + "> NOT SET!");
+        return registerEvaluator(expString, fieldName);
+    }
+
+    /**
+     * Returns true if all checks have passed.
+     * @return
+     */
+    public boolean allCheckedPassed() {
+        for (Checker c : checkers) {
+            if (!c.isValid()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get all errors detected in this error checker.
+     * @return
+     */
+    public List<String> getErrors() {
+        List<String> errors = new ArrayList<>();
+        for (Checker c : checkers) {
+            if (c.isValid()) {
+                continue;
+            }
+
+            for (String err : c.getErrors()) {
+                String formattedError = "";
+                if (!c.getTag().isBlank()) {
+                    formattedError += String.format("(%s)", c.getTag());
+                }
+                formattedError += String.format("%s", err);
+
+                errors.add(formattedError);
+            }
+        }
+        return errors;
+    }
+}

--- a/mcarcinizer/src/main/resources/deathkeeper.yml
+++ b/mcarcinizer/src/main/resources/deathkeeper.yml
@@ -17,9 +17,9 @@ deathkeeper:
 
   # Available var:
   #   LVL (deathkeeper level)
-  attack_expr: '2 + 0.2 * LVL'
-  hp_expr: '4 + LVL'
-  speed_expr: 'min(0.15 + 0.0025 * LVL, 0.4)'
+  attack_expr: '2 + 0.2 * DK_LVL'
+  hp_expr: '4 + DK_LVL'
+  speed_expr: 'min(0.15 + 0.0025 * DK_LVL, 0.4)'
 
   name: "{DK_OWNER}'s DeathKeeper Lv.{DK_LEVEL}"
   death_message: "§e{DK_OWNER}'s Deathkeeper Lv.{DK_LEVEL} §7, spawned the §e{DK_DATE}§7 at §e{DK_HOUR}§7 has been killed !"

--- a/mcarcinizer/src/main/resources/plugin.yml
+++ b/mcarcinizer/src/main/resources/plugin.yml
@@ -9,3 +9,7 @@ commands:
     description: Reloads all MCarcinizer subplugins.
     usage: /carcreload
     permission: carc.reload
+  invsize:
+    description: View inventory size (useful for config balancing)
+    usage: /invsize
+    permission: carc.invsize

--- a/mcarcinizer/src/main/resources/plugin.yml
+++ b/mcarcinizer/src/main/resources/plugin.yml
@@ -13,3 +13,7 @@ commands:
     description: View inventory size (useful for config balancing)
     usage: /invsize
     permission: carc.invsize
+  carcchkcfg:
+    description: Checks all MCarcinizer config files for errors.
+    usage: /carcchkcfg
+    permission: carc.carcchkcfg


### PR DESCRIPTION
Closes #9 

## Features added
- Checks for errors in all subplugins config files
- Command /carcchkcfg to list errors
- Command /invsize to see the inventory size (for deathkeeper formula balancing)

## Changes
- All deathkeeper formulas now use DK_LVL instead of LVL to disambiguate dk's level from player's level
- Update Github CI's JDK to JDK 11, needed for List.of() function
