### PR TITLE
Add configurable deathkeeper ban message

### DIFF
--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/config/DkConfig.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/config/DkConfig.java
@@ -27,8 +27,12 @@ public class DkConfig extends ConfigAccessor {
     private static final String CFG_DEATHKEEPER_DEATH_MSG = "deathkeeper.death_message";
     private static final String CFG_BAN_ON_DEATH = "deathkeeper.ban_on_death";
     private static final String CFG_DEATH_BAN_EXPR = "deathkeeper.death_ban_expr";
+    private static final String CFG_DEATH_BAN_MESSAGE = "deathkeeper.death_ban_message";
 
     private static final String VARIABLE_DK_LVL = "DK_LVL";
+    private static final String TOKEN_UNBAN_DATE = "{UNBAN_DATE}";
+    private static final String TOKEN_DEATH_REASON = "{DEATH_REASON}";
+    private static final String TOKEN_PLAYER_NAME = "{PLAYER_NAME}";
 
     public DkConfig(final FileConfiguration config) {
         super(config);
@@ -154,6 +158,22 @@ public class DkConfig extends ConfigAccessor {
         }
 
         return Math.max(0, evaluator.evaluate());
+    }
+
+    /**
+     * Get the ban reason/ban message that will be given to the player.
+     * @param p
+     * @param unbanDate
+     * @param deathMessage
+     * @return
+     */
+    public String getDeathBanMessage(Player p, Date unbanDate, String deathMessage) {
+        String template = config.getString(CFG_DEATH_BAN_MESSAGE, TOKEN_DEATH_REASON + " ..?");
+
+        return template
+                .replace(TOKEN_DEATH_REASON, deathMessage)
+                .replace(TOKEN_UNBAN_DATE, unbanDate.toString())
+                .replace(TOKEN_PLAYER_NAME, p.getName());
     }
 
     /**

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/listeners/ClassicDkListener.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/deathkeeper/listeners/ClassicDkListener.java
@@ -62,16 +62,19 @@ public class ClassicDkListener implements Listener {
 
             if (banTime > 0) {
                 Instant expireInstant = Instant.now().plusSeconds((long) banTime);
+                Date expireDate = Date.from(expireInstant);
+                String banMessage = config.getDeathBanMessage(p, expireDate, e.getDeathMessage());
+
                 final BanList banlist = singleton.getOwner().getServer().getBanList(Type.NAME);
                 banlist.addBan(
                     p.getName(),
-                    e.getDeathMessage(),
-                    Date.from(expireInstant),
-                    "deathkeeper");
+                    banMessage,
+                    expireDate,
+                    DeathKeeperSubplugin.getSingleton().getName());
 
                 Bukkit.getScheduler().runTask(
                     CarcinizerMain.getSingleton(),
-                    () -> p.kickPlayer(e.getDeathMessage()));
+                    () -> p.kickPlayer(banMessage));
             }
         }
     }

--- a/mcarcinizer/src/main/resources/deathkeeper.yml
+++ b/mcarcinizer/src/main/resources/deathkeeper.yml
@@ -31,3 +31,4 @@ deathkeeper:
   # Time to ban the player after dying (in seconds)
   # Stats available, aswell as INVSIZE, XP and DK_LVL
   death_ban_expr: '(5 + 40*log(DK_LVL+1)) + (1200 - 2*(TIME_SINCE_DEATH/20))'
+  death_ban_message: "Your soul is exhausted, please sit in limbo for some time... Cause of death : {DEATH_REASON}"


### PR DESCRIPTION
Closes #7 

New option in Deathkeeper config file : `deathkeeper.death_ban_message`, contains the message sent to players banned after dying.

Accepted tokens:
- `{DEATH_REASON}` : minecraft's default death reason
- `{PLAYER_NAME}` : banned player's name
- `{UNBAN_DATE}` : unban date (the formatting can't be edited, and in any case it is displayed to the player when he tries to log back)