### PR TITLE
Fix armor not taking damage w/ HH's health system

### DIFF
--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/vanilla/ArmorDamageFormulas.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/carcinizer/vanilla/ArmorDamageFormulas.java
@@ -1,0 +1,137 @@
+package com.kraby.mcarcinizer.carcinizer.vanilla;
+
+import com.kraby.mcarcinizer.CarcinizerMain;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ArmorDamageFormulas {
+
+    private ArmorDamageFormulas() {
+    }
+
+    /**
+     * Get the chance of an armor to have its durability used w/ a certain unbreaking level.
+     * Chance between 0.0 and 1.0
+     * @param unbreakingLevel The unbreaking enchantment level
+     * @return
+     */
+    public static float getArmorUseDurabilityChance(final int unbreakingLevel) {
+        return Math.min(
+                1.0f,
+                0.6f + (0.4f / (unbreakingLevel + 1))
+                );
+    }
+
+    /**
+     * Get how much durability an armor loses from taking a certain amount of damages.
+     * @param damages
+     * @return
+     */
+    public static double getArmorDurabilityDamaged(final double damages) {
+        // Any hit from a damage source that can be blocked by armor removes one point of
+        // durability from each piece of armor worn for every 4 (♥♥) of incoming damage
+        // (rounded down, but never below 1).
+        // Source: https://minecraft.fandom.com/wiki/Armor#Durability
+        return Math.max(1.0, Math.floor(damages / 4.0));
+    }
+
+    /**
+     * Returns true if the given armor will lose durability due to this damage cause.
+     * @param armorPiece
+     * @param cause
+     * @return
+     */
+    public static boolean isDamageCauseDurabilityUser(
+        final ItemStack armorPiece, final DamageCause cause) {
+
+        switch (cause) {
+            case BLOCK_EXPLOSION:
+                return true;
+            case CONTACT:
+                return true;
+            case ENTITY_ATTACK:
+                return true;
+            case ENTITY_EXPLOSION:
+                return true;
+            case ENTITY_SWEEP_ATTACK:
+                return true;
+            case HOT_FLOOR:
+                return true;
+            case LAVA:
+                return armorPiece.getType() == Material.NETHERITE_BOOTS
+                    || armorPiece.getType() == Material.NETHERITE_LEGGINGS
+                    || armorPiece.getType() == Material.NETHERITE_CHESTPLATE
+                    || armorPiece.getType() == Material.NETHERITE_HELMET;
+            case PROJECTILE:
+                return true;
+            case FALLING_BLOCK:
+                return true;
+            case THORNS:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+
+    /**
+     * Simulate an armor losing durability. Takes into account damage type, enchants, etc.
+     * @param armorPiece
+     * @param damages
+     * @param cause
+     * @return The points of durability lost.
+     */
+    public static int simulateArmorDurabilityHit(
+        final ItemStack armorPiece, final double damages, final DamageCause cause) {
+
+        // If the armor doesn't take these damages, no durability used
+        if (!isDamageCauseDurabilityUser(armorPiece, cause)) {
+            return 0;
+        }
+
+        int unbreakingLevel = armorPiece.getEnchantmentLevel(Enchantment.DURABILITY);
+        float useDurabilityChance = getArmorUseDurabilityChance(unbreakingLevel);
+        if (Math.random() >= useDurabilityChance) {
+            return 0;
+        }
+
+        return (int) Math.round(getArmorDurabilityDamaged(damages));
+    }
+
+
+    /**
+     * Returns the armorstack damaged.
+     * Must be ONLY armor.
+     * @param armorContents
+     * @param damages
+     * @param cause
+     * @return
+     */
+    public static ItemStack[] getDamagedArmorStack(
+        final ItemStack[] armorContents, final double damages, final DamageCause cause) {
+
+        ItemStack[] damagedStack = new ItemStack[armorContents.length];
+
+        // Damage each armor piece
+        for (int i = 0; i < armorContents.length; i++) {
+            // This piece of armor isn't worn : skip
+            if (armorContents[i] == null) {
+                continue;
+            }
+            // Damage the piece of armor
+            damagedStack[i] = armorContents[i].clone();
+            if (damagedStack[i].getItemMeta() instanceof Damageable) {
+                Damageable dmgTarget = (Damageable)damagedStack[i].getItemMeta();
+                int durabilityHit = simulateArmorDurabilityHit(armorContents[i], damages, cause);
+                dmgTarget.setDamage(dmgTarget.getDamage() + durabilityHit);
+                damagedStack[i].setItemMeta((ItemMeta)dmgTarget);
+            }
+        }
+
+        return damagedStack;
+    }
+}

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/listeners/RegenListener.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/listeners/RegenListener.java
@@ -20,14 +20,7 @@ public class RegenListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityReceiveDamage(EntityDamageEvent e) {
         if (e.getEntityType() == EntityType.PLAYER) {
-            Player p = (Player)e.getEntity();
-            double damages = e.getFinalDamage();
-
-            double newLife = CustomRegenLogic.getUnifiedHealth(p) - damages;
-            if (newLife > 0.0) {
-                e.setDamage(0.0);
-                CustomRegenLogic.setUnifiedHealth(p, newLife);
-            }
+            CustomRegenLogic.applyDamageEventPlayerUnifiedHealth(e);
         }
     }
 

--- a/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/logic/CustomRegenLogic.java
+++ b/mcarcinizer/src/main/java/com/kraby/mcarcinizer/healthhardcorizer/logic/CustomRegenLogic.java
@@ -1,12 +1,15 @@
 package com.kraby.mcarcinizer.healthhardcorizer.logic;
 
+import com.kraby.mcarcinizer.carcinizer.vanilla.ArmorDamageFormulas;
 import com.kraby.mcarcinizer.healthhardcorizer.HealthHardcorizerSubplugin;
 import com.kraby.mcarcinizer.healthhardcorizer.config.RegenConfig;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
 
 public class CustomRegenLogic {
-    private static final double MAX_HEALTH = 20.0d;
-
     // HP that keeps life from being full, in order to make the regen effect tick.
     private static final double HEALTH_OFFSET = 0.15d;
 
@@ -23,12 +26,13 @@ public class CustomRegenLogic {
      */
     public static double getUnifiedHealth(Player p) {
         RegenConfig config = HealthHardcorizerSubplugin.getSingleton().getRegenConfig();
+        final double maxHealth = p.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
 
         int minimumFood = config.getMinimumFood();
         double foodPointWorth = config.getFoodPointWorth();
         int useableFood = Math.max(0, p.getFoodLevel() - minimumFood);
 
-        double uhealth = Math.min(p.getHealth(), MAX_HEALTH - HEALTH_OFFSET);
+        double uhealth = Math.min(p.getHealth(), maxHealth - HEALTH_OFFSET);
         uhealth += useableFood * foodPointWorth;
 
         return uhealth;
@@ -44,12 +48,15 @@ public class CustomRegenLogic {
         RegenConfig config = HealthHardcorizerSubplugin.getSingleton().getRegenConfig();
 
         //If we set it to 20, the regeneration effect won't tick when the life is full
-        final double maxHealth = MAX_HEALTH - HEALTH_OFFSET;
+        final double maxHealth = p.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        final double cappedMaxHealth = maxHealth - HEALTH_OFFSET;
 
-        double uhealthNext = Math.max(0, uhealth - maxHealth);
+        // put everything we can in life
+        double uhealthNext = Math.max(0, uhealth - cappedMaxHealth);
         double heartsBar = uhealth - uhealthNext;
         p.setHealth(Math.max(0.001d, heartsBar));
 
+        // now put the rest in food
         uhealth = uhealthNext;
 
         int minimumFood = config.getMinimumFood();
@@ -60,6 +67,53 @@ public class CustomRegenLogic {
         p.setFoodLevel(foodBar);
     }
 
+    /**
+     * Apply a EntityDamageEvent to the player taking unified health into account.
+     * @param e
+     */
+    public static void applyDamageEventPlayerUnifiedHealth(EntityDamageEvent e) {
+        final RegenConfig config = HealthHardcorizerSubplugin.getSingleton().getRegenConfig();
+
+        final Player p = (Player)e.getEntity();
+
+        final double maxHealth = p.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        // final double cappedMaxHealth = maxHealth - HEALTH_OFFSET;
+        final int minimumFood = config.getMinimumFood();
+        final double foodPointWorth = config.getFoodPointWorth();
+
+        final double damages = e.getFinalDamage();
+
+        final double oldUHealth = getUnifiedHealth(p);
+        final double oldUFoodPart = Math.max(0, oldUHealth - maxHealth) / foodPointWorth;
+
+        final double newUHealth = oldUHealth - damages;
+        final double newUFoodPart = Math.max(0, newUHealth - maxHealth) / foodPointWorth;
+
+        // We have a food part in the unified health => custom behaviour
+        if (oldUFoodPart > 0) {
+            double healed = (oldUFoodPart - newUFoodPart);
+            // Some armor damage isn't applied due to the event damage being reduced/negated.
+            // Track them & apply them manually.
+            double manualArmorDamage = 0.0;
+
+            if (damages > p.getHealth() && newUHealth > 0) {
+                e.setDamage(p.getHealth() - HEALTH_OFFSET);
+                manualArmorDamage = damages;
+            } else {
+                e.setDamage(damages - healed);
+                manualArmorDamage = healed;
+            }
+            p.setFoodLevel(minimumFood + (int)(newUFoodPart / foodPointWorth));
+
+            // Manual damages/durability on armor
+            final EntityEquipment pEquipment = p.getEquipment();
+            ItemStack[] newDamagedArmor = ArmorDamageFormulas.getDamagedArmorStack(
+                pEquipment.getArmorContents(),
+                manualArmorDamage,
+                e.getCause());
+            pEquipment.setArmorContents(newDamagedArmor);
+        }
+    }
 
     /**
      * Adds a given amount of life to the player's unified health.


### PR DESCRIPTION
# Problem
Armor wasn't taking damage (or had reduced damage) when the HealthHardcorizer alt health system was enabled.

# Cause
The alternative health system cancels damages and instead reduces the food bar. This messes up with Minecraft's damage on armor durability.

# Fix
Add a class that emulates Minecraft's calculation. Not very elegant, but spigot does not seem to have an API for durability formulas. Fortunately, the formulas are quite simple and all contained in an **ArmorDamageFormulas** class.